### PR TITLE
feat: add OSENSA FTX 101 sensor support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 defmt = "0.3"
 embedded-hal = { version = "1", features = ["defmt-03"] }
+
+[features]
+# Enable support for OSENSA FTX 101 OEM sensor
+osensa = []

--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
-# Texas Instruments TMP-121 and TMP-123 drivers
+# Texas Instruments TMP-121/TMP-123 and OSENSA FTX 101 drivers
 
-This is a platform agnostic Rust driver for Texas Instruments TMP-121 and
-TMP-123 SPI devices, using the [`embedded-hal`] (v1) traits.
+This is a platform agnostic Rust driver for Texas Instruments TMP-121/TMP-123 
+and OSENSA FTX 101 OEM SPI temperature sensors, using the [`embedded-hal`] (v1) traits.
 
 This driver allows you to:
 
-- Read temperature measurement (see `get_reading()`)
+- Read temperature measurements (see `get_reading()`)
+- Read temperature with LED current diagnostics for FTX 101 (see `get_osensa_reading()` with `osensa` feature)
 
 It supports:
 
 - Blocking SPI using `embedded-hal 1.0`
+- Texas Instruments TMP-121 and TMP-123 sensors
+- OSENSA FTX 101 OEM sensor (with `osensa` feature flag)
 
 ## The devices
 
+### Texas Instruments TMP-121/TMP-123
 An example datasheet can be viewed for the
 [TMP-121/TMP-123](https://www.ti.com/lit/ds/symlink/tmp121.pdf)
+
+### OSENSA FTX 101 OEM
+The FTX 101 OEM sensor is compatible with the TMP123 data format but includes
+additional diagnostic features. Reference: Document No: MAN-DMK-0039B, 
+Revision No: A, Date: 16-NOV-18.
+
+Key differences when using the `osensa` feature:
+- **D2 bit (CFM)**: Confirmation bit indicates measurement validity (HIGH = valid, LOW = invalid)
+- **D1, D0 bits**: LED current level indicators
+- **Error codes**: 
+  - `0x0000`: No probe detected (LED disabled for 10s to extend unit life)
+  - `0x7FF8` (255°C): Device error (probe damaged or signal too weak)
 
 ## Usage
 
 To use this driver, import this crate and an `embedded-hal` (v1) implementation.
+
+### Basic Usage (TMP-121/TMP-123)
 
 The following example shows use of this driver using the
 [embassy](https://embassy.dev/) framework:
@@ -35,8 +53,51 @@ let spi = embassy_stm32::spi::Spi::new(
 
 // Combine the SPI bus and the CS pin into a SPI device. This now implements SpiDevice!
 let spi_device = embedded_hal_bus::spi::ExclusiveDevice::new(spi, cs_pin, embassy_time::Delay).unwrap();
-let temp_spi = ti_tmp_12x_rs::comms::Tmp12x::init(spi_device).unwrap();
+let mut temp_spi = ti_tmp_12x_rs::comms::Tmp12x::new(spi_device);
 
 // Do stuff
 let reading = temp_spi.get_reading().unwrap();
+```
+
+### OSENSA FTX 101 Usage
+
+To use with the OSENSA FTX 101 sensor, enable the `osensa` feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+ti-tmp12x-rs = { version = "0.1", features = ["osensa"] }
+```
+
+Then use the enhanced API:
+
+```rust
+use ti_tmp12x_rs::comms::{Tmp12x, OsensaReading, LedCurrentLevel};
+
+// ... setup SPI as above ...
+
+let mut temp_sensor = Tmp12x::new(spi_device);
+
+// Get temperature with validation (CFM bit checked)
+match temp_sensor.get_reading() {
+    Ok(temp) => println!("Temperature: {}°C", temp),
+    Err(Error::InvalidMeasurement) => println!("Measurement not ready"),
+    Err(Error::NoProbe) => println!("No probe detected"),
+    Err(Error::DeviceError) => println!("Device error (probe damaged or weak signal)"),
+    Err(e) => println!("Other error: {:?}", e),
+}
+
+// Get temperature with LED current diagnostics
+match temp_sensor.get_osensa_reading() {
+    Ok(reading) => {
+        println!("Temperature: {}°C", reading.temperature);
+        match reading.led_current {
+            LedCurrentLevel::Under500 => println!("LED current < 500"),
+            LedCurrentLevel::Range500To1000 => println!("LED current 500-1000"),
+            LedCurrentLevel::Range1000To2000 => println!("LED current 1000-2000"),
+            LedCurrentLevel::Over2000 => println!("LED current > 2000"),
+            LedCurrentLevel::Unknown => println!("LED current unknown"),
+        }
+    },
+    Err(e) => println!("Error: {:?}", e),
+}
 ```

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -4,6 +4,38 @@ use crate::error::Error;
 use core::fmt::Debug;
 use embedded_hal::spi::{Operation, SpiDevice};
 
+/// LED current level indication for OSENSA FTX 101 sensor.
+///
+/// This enum represents the LED current levels reported by the FTX 101
+/// through bits D1 and D0 of the temperature data packet.
+#[cfg(feature = "osensa")]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LedCurrentLevel {
+    /// LED current under 500 (0b00)
+    Under500,
+    /// LED current is greater than or equal to 500 but less than 1000 (0b01)
+    Range500To1000,
+    /// LED current is greater than or equal to 1000 but less than 2000 (0b10)
+    Range1000To2000,
+    /// LED current is greater than or equal to 2000 (0b11)
+    Over2000,
+    /// Unknown LED current level (should not occur with valid data)
+    Unknown,
+}
+
+/// Temperature reading with diagnostics from OSENSA FTX 101 sensor.
+///
+/// This struct contains both the temperature measurement and the
+/// LED current level diagnostic information provided by the FTX 101.
+#[cfg(feature = "osensa")]
+#[derive(Debug, Clone, Copy)]
+pub struct OsensaReading {
+    /// Temperature measurement in Celsius
+    pub temperature: f64,
+    /// LED current level indicator
+    pub led_current: LedCurrentLevel,
+}
+
 pub struct Tmp12x<SPI> {
     spi: SPI,
 }
@@ -36,6 +68,46 @@ fn convert_words(words: &[u8; 2]) -> f64 {
     temperature as f64 * 0.0625
 }
 
+#[cfg(feature = "osensa")]
+fn convert_words_osensa<SPI: embedded_hal::spi::SpiDevice>(words: &[u8; 2]) -> Result<(f64, LedCurrentLevel), Error<SPI>> {
+    // For FTX 101: Same temperature format as TMP123 but with additional bits:
+    // D2: CFM (confirmation) bit - HIGH = valid, LOW = invalid
+    // D1, D0: LED current level indicators
+    let all_bits = u16::from_be_bytes(*words);
+
+    // Check for special error values
+    if all_bits == 0x0000 {
+        // No probe detected
+        return Err(Error::NoProbe);
+    }
+    if all_bits == 0x7FF8 {
+        // Device error (255°C)
+        return Err(Error::DeviceError);
+    }
+
+    // Extract CFM bit (D2) and check validity
+    let is_valid = (all_bits & 0x0004) != 0;
+    if !is_valid {
+        // Measurement is not valid
+        return Err(Error::InvalidMeasurement);
+    }
+
+    // Extract LED current level (D1, D0)
+    let led_bits = (all_bits & 0x0003) as u8;
+    let led_current = match led_bits {
+        0b00 => LedCurrentLevel::Under500,
+        0b01 => LedCurrentLevel::Range500To1000,
+        0b10 => LedCurrentLevel::Range1000To2000,
+        0b11 => LedCurrentLevel::Over2000,
+        _ => LedCurrentLevel::Unknown,
+    };
+
+    // Calculate temperature using the existing convert_words function
+    let temp_celsius = convert_words(words);
+
+    Ok((temp_celsius, led_current))
+}
+
 impl<SPI> Tmp12x<SPI>
 where
     SPI: SpiDevice,
@@ -44,22 +116,101 @@ where
         Self { spi }
     }
 
-    /// Get a temperature readings in Celsius
-    /// Note - if a value of 0 is returned the sensor is probably not connected
-    /// or hasn't read anything yet - so this measurement should probably be
-    /// discarded
+    /// Get a temperature reading in Celsius.
+    ///
+    /// # Behavior
+    /// 
+    /// When the `osensa` feature is **disabled** (TMP121/TMP123):
+    /// - Returns the temperature directly from the sensor
+    /// - Note: if 0°C is returned, the sensor might not be connected or hasn't 
+    ///   completed its first conversion yet
+    ///
+    /// When the `osensa` feature is **enabled** (FTX 101):
+    /// - Validates the measurement using the CFM (confirmation) bit
+    /// - Returns `Err(Error::InvalidMeasurement)` if CFM bit is LOW
+    /// - Returns `Err(Error::NoProbe)` if no probe is detected (0x0000)
+    /// - Returns `Err(Error::DeviceError)` if device error detected (0x7FF8)
+    /// - LED current level is read but discarded (use `get_osensa_reading()` to access it)
+    ///
+    /// # Errors
+    /// 
+    /// - `Error::Spi` - SPI communication error
+    /// - `Error::InvalidMeasurement` - Measurement not ready (osensa only)
+    /// - `Error::NoProbe` - No probe detected (osensa only)
+    /// - `Error::DeviceError` - Probe damaged or signal weak (osensa only)
     pub fn get_reading(&mut self) -> Result<f64, Error<SPI>> {
         let mut words = [0u8; 2];
         self.spi
             .transaction(&mut [Operation::Read(&mut words)])
             .map_err(Error::Spi)?;
+
+        #[cfg(feature = "osensa")]
+        {
+            // For FTX 101, validate the measurement using the CFM bit
+            let (temperature, _led_current) = convert_words_osensa::<SPI>(&words)?;
+            Ok(temperature)
+        }
+
+        #[cfg(not(feature = "osensa"))]
         Ok(convert_words(&words))
     }
+
+    /// Get a temperature reading with LED current diagnostics (OSENSA FTX 101 only).
+    ///
+    /// This method returns both the temperature measurement and LED current level
+    /// information provided by the FTX 101 sensor. The reading is validated using
+    /// the CFM (confirmation) bit.
+    ///
+    /// # Returns
+    /// - `Ok(OsensaReading)` - Valid temperature reading with diagnostics
+    /// - `Err(Error::InvalidMeasurement)` - CFM bit indicates invalid measurement
+    /// - `Err(Error::NoProbe)` - No probe detected (device returns 0x0000)
+    /// - `Err(Error::DeviceError)` - Device error (device returns 0x7FF8)
+    /// - `Err(Error::Spi)` - SPI communication error
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use ti_tmp12x_rs::comms::{Tmp12x, OsensaReading, LedCurrentLevel};
+    /// # use embedded_hal::spi::SpiDevice;
+    /// # fn example<SPI: SpiDevice>(mut sensor: Tmp12x<SPI>) {
+    /// match sensor.get_osensa_reading() {
+    ///     Ok(reading) => {
+    ///         println!("Temperature: {}°C", reading.temperature);
+    ///         match reading.led_current {
+    ///             LedCurrentLevel::Under500 => println!("LED current < 500"),
+    ///             LedCurrentLevel::Range500To1000 => println!("LED current 500-1000"),
+    ///             LedCurrentLevel::Range1000To2000 => println!("LED current 1000-2000"),
+    ///             LedCurrentLevel::Over2000 => println!("LED current > 2000"),
+    ///             LedCurrentLevel::Unknown => println!("LED current unknown"),
+    ///         }
+    ///     },
+    ///     Err(e) => println!("Error: {:?}", e),
+    /// }
+    /// # }
+    /// ```
+    #[cfg(feature = "osensa")]
+    pub fn get_osensa_reading(&mut self) -> Result<OsensaReading, Error<SPI>> {
+        let mut words = [0u8; 2];
+        self.spi
+            .transaction(&mut [Operation::Read(&mut words)])
+            .map_err(Error::Spi)?;
+
+        let (temperature, led_current) = convert_words_osensa::<SPI>(&words)?;
+        Ok(OsensaReading {
+            temperature,
+            led_current,
+        })
+    }
+
 }
 
 #[cfg(test)]
 mod test {
     use super::convert_words;
+    #[cfg(feature = "osensa")]
+    use super::{convert_words_osensa, LedCurrentLevel};
+    #[cfg(feature = "osensa")]
+    use crate::error::Error;
 
     #[test]
     fn test_word_conversion() {
@@ -73,5 +224,69 @@ mod test {
         assert_eq!(convert_words(&[0xFF, 0xF8]), -0.0625);
         assert_eq!(convert_words(&[0xF3, 0x80]), -25.0);
         assert_eq!(convert_words(&[0xE4, 0x80]), -55.0);
+    }
+
+    #[cfg(feature = "osensa")]
+    #[test]
+    fn test_osensa_word_conversion() {
+        // Create a dummy SPI type for testing
+        use core::convert::Infallible;
+        struct DummySpi;
+        impl embedded_hal::spi::ErrorType for DummySpi {
+            type Error = Infallible;
+        }
+        impl embedded_hal::spi::SpiDevice for DummySpi {
+            fn transaction(&mut self, _operations: &mut [embedded_hal::spi::Operation<'_, u8>]) -> Result<(), Self::Error> {
+                Ok(())
+            }
+        }
+        
+        // Test valid measurement with CFM bit set (D2 = 1)
+        // 25°C with CFM=1, LED current = Under500 (0b00)
+        // 0x0C80 = 0000 1100 1000 0000 -> shift right 3 = 0001 1001 = 25°C
+        // With CFM bit: 0x0C84 = 0000 1100 1000 0100 (CFM=1, LED=00)
+        let result = convert_words_osensa::<DummySpi>(&[0x0C, 0x84]).unwrap();
+        assert_eq!(result.0, 25.0); // temperature
+        assert_eq!(result.1, LedCurrentLevel::Under500);
+
+        // Test invalid measurement with CFM bit clear (D2 = 0)
+        // Should return InvalidMeasurement error
+        assert!(matches!(
+            convert_words_osensa::<DummySpi>(&[0x0C, 0x80]),
+            Err(Error::InvalidMeasurement)
+        ));
+
+        // Test LED current levels with valid CFM
+        // LED = 0b01 (Range500To1000)
+        let result = convert_words_osensa::<DummySpi>(&[0x0C, 0x85]).unwrap();
+        assert_eq!(result.1, LedCurrentLevel::Range500To1000);
+
+        // LED = 0b10 (Range1000To2000)
+        let result = convert_words_osensa::<DummySpi>(&[0x0C, 0x86]).unwrap();
+        assert_eq!(result.1, LedCurrentLevel::Range1000To2000);
+
+        // LED = 0b11 (Over2000)
+        let result = convert_words_osensa::<DummySpi>(&[0x0C, 0x87]).unwrap();
+        assert_eq!(result.1, LedCurrentLevel::Over2000);
+
+        // Test error conditions
+        // No probe detected (0x0000)
+        assert!(matches!(
+            convert_words_osensa::<DummySpi>(&[0x00, 0x00]),
+            Err(Error::NoProbe)
+        ));
+
+        // Device error (0x7FF8 = 255°C error code)
+        assert!(matches!(
+            convert_words_osensa::<DummySpi>(&[0x7F, 0xF8]),
+            Err(Error::DeviceError)
+        ));
+
+        // Test negative temperature with CFM and LED bits
+        // -25°C = 0xF380, with CFM=1, LED=10
+        // 0xF386 = 1111 0011 1000 0110
+        let result = convert_words_osensa::<DummySpi>(&[0xF3, 0x86]).unwrap();
+        assert_eq!(result.0, -25.0);
+        assert_eq!(result.1, LedCurrentLevel::Range1000To2000);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,26 @@ use embedded_hal::spi::SpiDevice;
 pub enum Error<SPI: SpiDevice> {
     /// An SPI transfer failed.
     Spi(SPI::Error),
+
+    /// The measurement is invalid (CFM bit is LOW).
+    /// Only returned when the `osensa` feature is enabled.
+    /// This indicates the FTX 101 sensor has not yet completed a valid measurement.
+    #[cfg(feature = "osensa")]
+    InvalidMeasurement,
+
+    /// No probe is detected (device returns 0x0000).
+    /// Only returned when the `osensa` feature is enabled.
+    /// The FTX 101 disables the LED for 10s when no probe is detected to extend unit life.
+    #[cfg(feature = "osensa")]
+    NoProbe,
+
+    /// Device error detected (device returns 0x7FF8, corresponding to 255°C).
+    /// Only returned when the `osensa` feature is enabled.
+    /// This may indicate:
+    /// - Probe is damaged
+    /// - Signal is too weak
+    #[cfg(feature = "osensa")]
+    DeviceError,
 }
 
 impl<SPI: SpiDevice> Format for Error<SPI>
@@ -18,6 +38,12 @@ where
     fn format(&self, fmt: Formatter) {
         match self {
             Error::Spi(_spi) => defmt::write!(fmt, "Error::Spi"),
+            #[cfg(feature = "osensa")]
+            Error::InvalidMeasurement => defmt::write!(fmt, "Error::InvalidMeasurement"),
+            #[cfg(feature = "osensa")]
+            Error::NoProbe => defmt::write!(fmt, "Error::NoProbe"),
+            #[cfg(feature = "osensa")]
+            Error::DeviceError => defmt::write!(fmt, "Error::DeviceError"),
         }
     }
 }
@@ -28,6 +54,12 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Spi(spi) => write!(f, "Error::Spi({:?})", spi),
+            #[cfg(feature = "osensa")]
+            Error::InvalidMeasurement => write!(f, "Error::InvalidMeasurement"),
+            #[cfg(feature = "osensa")]
+            Error::NoProbe => write!(f, "Error::NoProbe"),
+            #[cfg(feature = "osensa")]
+            Error::DeviceError => write!(f, "Error::DeviceError"),
         }
     }
 }


### PR DESCRIPTION
- Add osensa feature flag for opt-in FTX 101 compatibility
- Add error variants for InvalidMeasurement, NoProbe, and DeviceError
- Implement CFM bit validation for measurement validity
- Add LED current level diagnostics (LedCurrentLevel enum)
- Add get_osensa_reading() method for full diagnostics
- Update get_reading() to validate CFM bit when feature enabled
- Add comprehensive tests for FTX 101 functionality
- Update documentation with usage examples

Reference: Document No: MAN-DMK-0039B, Revision No: A, Date: 16-NOV-18